### PR TITLE
Plugin: Deposit Lock: Hexens Audit

### DIFF
--- a/src/libraries/LibErrors.sol
+++ b/src/libraries/LibErrors.sol
@@ -157,15 +157,21 @@ library LibErrors {
     /**
      * @dev The requested shares to remove is not available.
      * @param requested The requested shares to remove.
-     * @param remaining Remaining shares from requested amount.
+     * @param available The available shares to remove.
      */
-    error NotEnoughShares(uint256 requested, uint256 remaining);
+    error NotEnoughShares(uint256 requested, uint256 available);
 
     /**
-     * @dev The unlock time exceeds the current block timestamp.
+     * @dev The project is still locked, withdrawals are not allowed.
      * @param unlockTime The unlock time.
      */
     error GlobalUnlockTimeNotReached(uint256 unlockTime);
+
+    /**
+     * @dev Project is unlocked, deposits are not allowed.
+     * @param unlockTime The unlock time.
+     */
+    error GlobalUnlockTimeReached(uint256 unlockTime);
 
     /**
      * @dev The lock mode is already set for the project.


### PR DESCRIPTION
`YELAY4-1: Reentrancy in deposit function`
Acknowledged, fixed at 7d19b8bb5fe757109e5a30fa91c032b97a0aebfd.

`Yelay4-13: Use safe transfer for ERC20 tokens`
Acknowledged, fixed.

`Yelay4-15: Total assets tracking does not take slippage into account`
Not acknowledged, will be not fixed. No such strategies will be used in Yelay Lite vaults. It is acknowledged that there might be 1 wei discrepancy initially for `strategyAssets`, but otherwise no risk for slippages.

`Yelay4-10: Event calculates and returns wrong value with a vague error name`
The intent of the error 'NotEnoughShares' is to emit both the *requested* and the *available* shares, if there is not enough shares to remove. We acknowledge that the use of 'remaining' in NotEnoughShares is confusing, so have updated the parameter name in the error. using `current` in _removeSharesGlobal and `shares-remaining` in _removeSharesVariable should therefore be consistent - ie. we are emitting the overall shares that are available to remove in the second argument.

`Yelay4-6: Missing clientOwner Validation Can Cause DoS on updateLockPeriod and updateGlobalUnlockTime for Old Project IDs`
Acknowledged, will be not fixed. This function is managed by the Yelay as Vault Owner, not clientOwner itself.

`Yelay4-4: updateGlobalUnlockTime Could Lock Users Permanently`
Acknowledged, won't fix. Owner can also just update the contracts regardless, and therefore we are happy with the existing logic.

`Yelay4-3: Use unchecked when it is safe`
Acknowledged, fixed.

`Yelay4-2: Users can still deposit into a global lock project after a finished deadline.`
Acknowledged, fixed.
