### PR TITLE
Claim and redeem feature

### DIFF
--- a/.openzeppelin/arbitrum-one.json
+++ b/.openzeppelin/arbitrum-one.json
@@ -1245,6 +1245,319 @@
           ]
         }
       }
+    },
+    "6147d35bcc3b7db5c86e014d41d65ed544b27483ccf4495b8daa85a270d71c95": {
+      "address": "0xF3b5E160898CFd8b89476e77887050aBB377C277",
+      "txHash": "0xef1e864508a84cffbffb7027ac4a4e506bed13844a332f5406de03158de05f99",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "cycleCount",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:54"
+          },
+          {
+            "label": "roots",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:60"
+          },
+          {
+            "label": "isLeafClaimed",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:65"
+          },
+          {
+            "label": "yieldSharesClaimed",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:71"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlDefaultAdminRulesStorage)2533_storage": {
+            "label": "struct AccessControlDefaultAdminRulesUpgradeable.AccessControlDefaultAdminRulesStorage",
+            "members": [
+              {
+                "label": "_pendingDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_pendingDefaultAdminSchedule",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDelay",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelay",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelaySchedule",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AccessControlStorage)2326_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)2841_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)3856_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)2316_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))": {
+            "label": "mapping(address => mapping(address => mapping(uint256 => uint256)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))": {
+            "label": "mapping(address => mapping(uint256 => struct Root))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Root)25726_storage)": {
+            "label": "mapping(uint256 => struct Root)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Root)25726_storage": {
+            "label": "struct Root",
+            "members": [
+              {
+                "label": "hash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "blockNumber",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControlDefaultAdminRules": [
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:45",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdminSchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:46",
+              "offset": 20,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:48",
+              "offset": 26,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:49",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:52",
+              "offset": 20,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelaySchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:53",
+              "offset": 26,
+              "slot": "1"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/avalanche.json
+++ b/.openzeppelin/avalanche.json
@@ -1245,6 +1245,319 @@
           ]
         }
       }
+    },
+    "6147d35bcc3b7db5c86e014d41d65ed544b27483ccf4495b8daa85a270d71c95": {
+      "address": "0xba46296D9Df12344aCC0305Fa2b49638a90dc40d",
+      "txHash": "0xaf4203afa4c5f0883e18073b95d8842962d1c2652707fa92b2a7fb72ad24585d",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "cycleCount",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:54"
+          },
+          {
+            "label": "roots",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:60"
+          },
+          {
+            "label": "isLeafClaimed",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:65"
+          },
+          {
+            "label": "yieldSharesClaimed",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:71"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlDefaultAdminRulesStorage)2533_storage": {
+            "label": "struct AccessControlDefaultAdminRulesUpgradeable.AccessControlDefaultAdminRulesStorage",
+            "members": [
+              {
+                "label": "_pendingDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_pendingDefaultAdminSchedule",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDelay",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelay",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelaySchedule",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AccessControlStorage)2326_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)2841_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)3856_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)2316_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))": {
+            "label": "mapping(address => mapping(address => mapping(uint256 => uint256)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))": {
+            "label": "mapping(address => mapping(uint256 => struct Root))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Root)25726_storage)": {
+            "label": "mapping(uint256 => struct Root)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Root)25726_storage": {
+            "label": "struct Root",
+            "members": [
+              {
+                "label": "hash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "blockNumber",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControlDefaultAdminRules": [
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:45",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdminSchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:46",
+              "offset": 20,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:48",
+              "offset": 26,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:49",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:52",
+              "offset": 20,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelaySchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:53",
+              "offset": 26,
+              "slot": "1"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/base.json
+++ b/.openzeppelin/base.json
@@ -1665,6 +1665,319 @@
           ]
         }
       }
+    },
+    "6147d35bcc3b7db5c86e014d41d65ed544b27483ccf4495b8daa85a270d71c95": {
+      "address": "0x1857d8Ca0F82C7Df18F1ca6576687Cb4cebeB8F0",
+      "txHash": "0x8e6716e87ff1149e0f02b7c4b282563c95c3e5fff18b96e2aeb203ec63760095",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "cycleCount",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:54"
+          },
+          {
+            "label": "roots",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:60"
+          },
+          {
+            "label": "isLeafClaimed",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:65"
+          },
+          {
+            "label": "yieldSharesClaimed",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:71"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlDefaultAdminRulesStorage)2533_storage": {
+            "label": "struct AccessControlDefaultAdminRulesUpgradeable.AccessControlDefaultAdminRulesStorage",
+            "members": [
+              {
+                "label": "_pendingDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_pendingDefaultAdminSchedule",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDelay",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelay",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelaySchedule",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AccessControlStorage)2326_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)2841_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)3856_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)2316_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))": {
+            "label": "mapping(address => mapping(address => mapping(uint256 => uint256)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))": {
+            "label": "mapping(address => mapping(uint256 => struct Root))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Root)25726_storage)": {
+            "label": "mapping(uint256 => struct Root)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Root)25726_storage": {
+            "label": "struct Root",
+            "members": [
+              {
+                "label": "hash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "blockNumber",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControlDefaultAdminRules": [
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:45",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdminSchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:46",
+              "offset": 20,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:48",
+              "offset": 26,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:49",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:52",
+              "offset": 20,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelaySchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:53",
+              "offset": 26,
+              "slot": "1"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/mainnet.json
+++ b/.openzeppelin/mainnet.json
@@ -1558,6 +1558,319 @@
           ]
         }
       }
+    },
+    "6147d35bcc3b7db5c86e014d41d65ed544b27483ccf4495b8daa85a270d71c95": {
+      "address": "0x195F5dE85b0373d0752E781EABD1c0bfE33C10D5",
+      "txHash": "0x26f861c9724e4b50d69fc1ac06282b6301fd2df23fe1a19cc7816f86f625a3e3",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "cycleCount",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:54"
+          },
+          {
+            "label": "roots",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:60"
+          },
+          {
+            "label": "isLeafClaimed",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:65"
+          },
+          {
+            "label": "yieldSharesClaimed",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:71"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlDefaultAdminRulesStorage)2533_storage": {
+            "label": "struct AccessControlDefaultAdminRulesUpgradeable.AccessControlDefaultAdminRulesStorage",
+            "members": [
+              {
+                "label": "_pendingDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_pendingDefaultAdminSchedule",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDelay",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelay",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelaySchedule",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AccessControlStorage)2326_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)2841_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)3856_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)2316_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))": {
+            "label": "mapping(address => mapping(address => mapping(uint256 => uint256)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))": {
+            "label": "mapping(address => mapping(uint256 => struct Root))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Root)25726_storage)": {
+            "label": "mapping(uint256 => struct Root)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Root)25726_storage": {
+            "label": "struct Root",
+            "members": [
+              {
+                "label": "hash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "blockNumber",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControlDefaultAdminRules": [
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:45",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdminSchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:46",
+              "offset": 20,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:48",
+              "offset": 26,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:49",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:52",
+              "offset": 20,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelaySchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:53",
+              "offset": 26,
+              "slot": "1"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/.openzeppelin/sonic.json
+++ b/.openzeppelin/sonic.json
@@ -1706,6 +1706,319 @@
           ]
         }
       }
+    },
+    "6147d35bcc3b7db5c86e014d41d65ed544b27483ccf4495b8daa85a270d71c95": {
+      "address": "0xba3b9b1EC758918EBE8A30D56828592Ac3229Ef6",
+      "txHash": "0x658dd2b1b3c4f3053b1e109a58294ba80c494f42ff398c49d94e6270f6419839",
+      "layout": {
+        "solcVersion": "0.8.28",
+        "storage": [
+          {
+            "label": "cycleCount",
+            "offset": 0,
+            "slot": "0",
+            "type": "t_mapping(t_address,t_uint256)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:54"
+          },
+          {
+            "label": "roots",
+            "offset": 0,
+            "slot": "1",
+            "type": "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:60"
+          },
+          {
+            "label": "isLeafClaimed",
+            "offset": 0,
+            "slot": "2",
+            "type": "t_mapping(t_bytes32,t_bool)",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:65"
+          },
+          {
+            "label": "yieldSharesClaimed",
+            "offset": 0,
+            "slot": "3",
+            "type": "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))",
+            "contract": "YieldExtractor",
+            "src": "src\\YieldExtractor.sol:71"
+          }
+        ],
+        "types": {
+          "t_address": {
+            "label": "address",
+            "numberOfBytes": "20"
+          },
+          "t_bool": {
+            "label": "bool",
+            "numberOfBytes": "1"
+          },
+          "t_bytes32": {
+            "label": "bytes32",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_bool)": {
+            "label": "mapping(address => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)": {
+            "label": "mapping(bytes32 => struct AccessControlUpgradeable.RoleData)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(AccessControlDefaultAdminRulesStorage)2533_storage": {
+            "label": "struct AccessControlDefaultAdminRulesUpgradeable.AccessControlDefaultAdminRulesStorage",
+            "members": [
+              {
+                "label": "_pendingDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_pendingDefaultAdminSchedule",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDelay",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "0"
+              },
+              {
+                "label": "_currentDefaultAdmin",
+                "type": "t_address",
+                "offset": 0,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelay",
+                "type": "t_uint48",
+                "offset": 20,
+                "slot": "1"
+              },
+              {
+                "label": "_pendingDelaySchedule",
+                "type": "t_uint48",
+                "offset": 26,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_struct(AccessControlStorage)2326_storage": {
+            "label": "struct AccessControlUpgradeable.AccessControlStorage",
+            "members": [
+              {
+                "label": "_roles",
+                "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(InitializableStorage)2841_storage": {
+            "label": "struct Initializable.InitializableStorage",
+            "members": [
+              {
+                "label": "_initialized",
+                "type": "t_uint64",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "_initializing",
+                "type": "t_bool",
+                "offset": 8,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(PausableStorage)3856_storage": {
+            "label": "struct PausableUpgradeable.PausableStorage",
+            "members": [
+              {
+                "label": "_paused",
+                "type": "t_bool",
+                "offset": 0,
+                "slot": "0"
+              }
+            ],
+            "numberOfBytes": "32"
+          },
+          "t_struct(RoleData)2316_storage": {
+            "label": "struct AccessControlUpgradeable.RoleData",
+            "members": [
+              {
+                "label": "hasRole",
+                "type": "t_mapping(t_address,t_bool)",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "adminRole",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint48": {
+            "label": "uint48",
+            "numberOfBytes": "6"
+          },
+          "t_uint64": {
+            "label": "uint64",
+            "numberOfBytes": "8"
+          },
+          "t_mapping(t_address,t_mapping(t_address,t_mapping(t_uint256,t_uint256)))": {
+            "label": "mapping(address => mapping(address => mapping(uint256 => uint256)))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_struct(Root)25726_storage))": {
+            "label": "mapping(address => mapping(uint256 => struct Root))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_mapping(t_uint256,t_uint256))": {
+            "label": "mapping(address => mapping(uint256 => uint256))",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_address,t_uint256)": {
+            "label": "mapping(address => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_bytes32,t_bool)": {
+            "label": "mapping(bytes32 => bool)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_struct(Root)25726_storage)": {
+            "label": "mapping(uint256 => struct Root)",
+            "numberOfBytes": "32"
+          },
+          "t_mapping(t_uint256,t_uint256)": {
+            "label": "mapping(uint256 => uint256)",
+            "numberOfBytes": "32"
+          },
+          "t_struct(Root)25726_storage": {
+            "label": "struct Root",
+            "members": [
+              {
+                "label": "hash",
+                "type": "t_bytes32",
+                "offset": 0,
+                "slot": "0"
+              },
+              {
+                "label": "blockNumber",
+                "type": "t_uint256",
+                "offset": 0,
+                "slot": "1"
+              }
+            ],
+            "numberOfBytes": "64"
+          },
+          "t_uint256": {
+            "label": "uint256",
+            "numberOfBytes": "32"
+          }
+        },
+        "namespaces": {
+          "erc7201:openzeppelin.storage.AccessControlDefaultAdminRules": [
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:45",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDefaultAdminSchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:46",
+              "offset": 20,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:48",
+              "offset": 26,
+              "slot": "0"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_currentDefaultAdmin",
+              "type": "t_address",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:49",
+              "offset": 0,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelay",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:52",
+              "offset": 20,
+              "slot": "1"
+            },
+            {
+              "contract": "AccessControlDefaultAdminRulesUpgradeable",
+              "label": "_pendingDelaySchedule",
+              "type": "t_uint48",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\extensions\\AccessControlDefaultAdminRulesUpgradeable.sol:53",
+              "offset": 26,
+              "slot": "1"
+            }
+          ],
+          "erc7201:openzeppelin.storage.AccessControl": [
+            {
+              "contract": "AccessControlUpgradeable",
+              "label": "_roles",
+              "type": "t_mapping(t_bytes32,t_struct(RoleData)2316_storage)",
+              "src": "@openzeppelin-upgradeable\\contracts\\access\\AccessControlUpgradeable.sol:61",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Pausable": [
+            {
+              "contract": "PausableUpgradeable",
+              "label": "_paused",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\utils\\PausableUpgradeable.sol:21",
+              "offset": 0,
+              "slot": "0"
+            }
+          ],
+          "erc7201:openzeppelin.storage.Initializable": [
+            {
+              "contract": "Initializable",
+              "label": "_initialized",
+              "type": "t_uint64",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:69",
+              "offset": 0,
+              "slot": "0"
+            },
+            {
+              "contract": "Initializable",
+              "label": "_initializing",
+              "type": "t_bool",
+              "src": "@openzeppelin-upgradeable\\contracts\\proxy\\utils\\Initializable.sol:73",
+              "offset": 8,
+              "slot": "0"
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/deployments/arbitrum.json
+++ b/deployments/arbitrum.json
@@ -8,7 +8,7 @@
         "implementation": "0x24ae0218d9e33b27bbb8ad7c55b2be5a1083f14d"
     },
     "ownerFacet": "0x0A09027643d21F35df24f156694A97776d211907",
-    "fundsFacet": "0x1798b36C340DBA0A2bd7BD379dF100af07396e57",
+    "fundsFacet": "0xbA8911d42d27a281a27c301b3284167aC950Ad37",
     "accessFacet": "0xA7B78cB41B0923D41f002CCF32B95F00Be2c6f73",
     "managementFacet": "0xF9ED32A3B0E92ba991B60945744eFf95C7D5b421",
     "clientsFacet": "0x94cec01bCed84022c91Cd5bf4f424A5CC781deE3",
@@ -23,7 +23,7 @@
     },
     "yieldExtractor": {
         "proxy": "0x79b7e90F1BAe837362DBD2c83Bd0715c2De5E47f",
-        "implementation": "0xF4a23fC0f9beB15Df3d4e1a44425Ec559f746D4F"
+        "implementation": "0xF3b5E160898CFd8b89476e77887050aBB377C277"
     },
     "depositLockPlugin": {
         "proxy": "0x20E65eA03a1563Eb95bC7AC25F892D11D7a5D88f",

--- a/deployments/avalanche.json
+++ b/deployments/avalanche.json
@@ -8,7 +8,7 @@
         "implementation": "0x123db049cc5ee36010f5148000754181ab87b3b3"
     },
     "ownerFacet": "0xa1A32FC1573B8D0532845c833cF4e8eA205345f1",
-    "fundsFacet": "0x0A09027643d21F35df24f156694A97776d211907",
+    "fundsFacet": "0x4D6A89dc55d8bACC0cbC3824BD7e44fa051c3958",
     "accessFacet": "0x2e988479F14Ff61586F8Fd0F09E8720484Eb6030",
     "managementFacet": "0xf1963B270a167B308040C2a0C0E74D8f912f3ABb",
     "clientsFacet": "0xF4a23fC0f9beB15Df3d4e1a44425Ec559f746D4F",
@@ -22,7 +22,7 @@
     },
     "yieldExtractor": {
         "proxy": "0x98732e2FEb854bAd400D4b5336f4439E7E53fe88",
-        "implementation": "0x7Cdd48a57AD24BcE6195234B153b0b8a0ee3974f"
+        "implementation": "0xba46296D9Df12344aCC0305Fa2b49638a90dc40d"
     },
     "depositLockPlugin": {
         "proxy": "0x0872e8391662D4e53D6649c8dE5d4bF581Bd778C",

--- a/deployments/base-production.json
+++ b/deployments/base-production.json
@@ -8,7 +8,7 @@
         "implementation": "0xcf19f89addd88cba706fe94251ec3cf66611be43"
     },
     "ownerFacet": "0xdAB8e9B1976C724027BE339848811615279Dae4c",
-    "fundsFacet": "0xFE8aA2d7835a5022F853F01fDc042154ca4eD022",
+    "fundsFacet": "0x2ac50fc2fd5291143f9d2c7CF699BD8bf88fD2Be",
     "accessFacet": "0x5982506084271f49c48E809dB1893312D4915490",
     "managementFacet": "0xF4a23fC0f9beB15Df3d4e1a44425Ec559f746D4F",
     "clientsFacet": "0x19808E4fc707B0D17b7Ac91177537A7F8d6CDB5d",
@@ -28,7 +28,7 @@
     },
     "yieldExtractor": {
         "proxy": "0x4D6A89dc55d8bACC0cbC3824BD7e44fa051c3958",
-        "implementation": "0xE8671aF5617b520dEB8Cc630A9D4a7745817D62D"
+        "implementation": "0x1857d8Ca0F82C7Df18F1ca6576687Cb4cebeB8F0"
     },
     "erc4626Plugin": {
         "factory": "0x0aADeF25ac515c6f9cCAD2afD23fCf90209F7346",

--- a/deployments/base-testing.json
+++ b/deployments/base-testing.json
@@ -8,7 +8,7 @@
         "implementation": "0x28b905d160dacdc93160de62f01bb8f146f93d9d"
     },
     "ownerFacet": "0xdAB8e9B1976C724027BE339848811615279Dae4c",
-    "fundsFacet": "0xc40C2059e9Dc43fef251Cde69D63425441b733f6",
+    "fundsFacet": "0xe67DE5E147884C4484f9D1fe3BD6e0C50149b8fb",
     "accessFacet": "0x5982506084271f49c48E809dB1893312D4915490",
     "managementFacet": "0xF4a23fC0f9beB15Df3d4e1a44425Ec559f746D4F",
     "clientsFacet": "0x19808E4fc707B0D17b7Ac91177537A7F8d6CDB5d",
@@ -27,7 +27,7 @@
     },
     "yieldExtractor": {
         "proxy": "0xF3b5E160898CFd8b89476e77887050aBB377C277",
-        "implementation": "0xE8671aF5617b520dEB8Cc630A9D4a7745817D62D"
+        "implementation": "0x1857d8Ca0F82C7Df18F1ca6576687Cb4cebeB8F0"
     },
     "erc4626Plugin": {
         "factory": "0xaFb394CA38baAc51cd6d2Ca9A54F71AF40a6220b",

--- a/deployments/mainnet.json
+++ b/deployments/mainnet.json
@@ -8,7 +8,7 @@
         "implementation": "0x93ec44bccfce56c519a0cad5ff13a5d6d0e98256"
     },
     "ownerFacet": "0x353cA9444D78967E1F8cC14447f82b5b95133D65",
-    "fundsFacet": "0x0F648F6EAF4AE90Dc8b1Edf54D9aAA9dBe87B9F8",
+    "fundsFacet": "0xce0dE4c16cD7734202939BbeB03905cB750c6901",
     "accessFacet": "0xb61413b0E6811bA11A6B34534A8CE4AF69D504b4",
     "managementFacet": "0x0A09027643d21F35df24f156694A97776d211907",
     "clientsFacet": "0x45308fd10dEb8bDbe29872BC1FF500d9e6431bF6",
@@ -29,7 +29,7 @@
     },
     "yieldExtractor": {
         "proxy": "0x226239384EB7d78Cdf279BA6Fb458E2A4945E275",
-        "implementation": "0x55A6CbAeFF11414e3819B4C7Fc8dF5eE244eD315"
+        "implementation": "0x195F5dE85b0373d0752E781EABD1c0bfE33C10D5"
     },
     "erc4626Plugin": {
         "factory": "0x0aADeF25ac515c6f9cCAD2afD23fCf90209F7346",

--- a/deployments/sonic.json
+++ b/deployments/sonic.json
@@ -8,7 +8,7 @@
         "implementation": "0x119242eebda97066045a6e175e508aaeedbe8b68"
     },
     "ownerFacet": "0xB9d537443306cA76738407EE20367F1Edf478857",
-    "fundsFacet": "0x680eb0997BB85Ac6f89a2Aeec9bb9157cFDF0ED1",
+    "fundsFacet": "0x55A6CbAeFF11414e3819B4C7Fc8dF5eE244eD315",
     "accessFacet": "0x90b8695EDCdEfAFA678Df6d819307573f7B1a18C",
     "managementFacet": "0x0A09027643d21F35df24f156694A97776d211907",
     "clientsFacet": "0x910607fD3e0D1EF561Ee356c3aDF92b3DFb0CeA8",
@@ -27,7 +27,7 @@
     },
     "yieldExtractor": {
         "proxy": "0xB84B621D3da3E5e47A1927883C685455Ad731D7C",
-        "implementation": "0xdd4D9766B931d165E44890D0288A6f2Dd565AdEC"
+        "implementation": "0xba3b9b1EC758918EBE8A30D56828592Ac3229Ef6"
     },
     "feeMRegistrationPlugin": "0xF3b5E160898CFd8b89476e77887050aBB377C277",
     "erc4626Plugin": {

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -299,4 +299,5 @@ export const ROLES = {
     SWAP_REWARDS_OPERATOR: ethers.id('SWAP_REWARDS_OPERATOR'),
     PAUSER: ethers.id('PAUSER'),
     UNPAUSER: ethers.id('UNPAUSER'),
+    YIELD_PUBLISHER: ethers.id('YIELD_PUBLISHER'),
 };

--- a/scripts/utils/checks.ts
+++ b/scripts/utils/checks.ts
@@ -9,6 +9,7 @@ import {
     Swapper__factory,
     VaultWrapper,
     VaultWrapper__factory,
+    YieldExtractor__factory,
 } from '../../typechain-types';
 import { ExpectedAddresses, IMPLEMENTATION_STORAGE_SLOT, ROLES } from '../constants';
 import { warning } from './common';
@@ -67,6 +68,7 @@ export const checkSetup = async (
     {
         owner,
         yieldExtractor,
+        yieldPublisher,
         oneInchRouter,
         strategyAuthority,
         fundsOperator,
@@ -113,6 +115,25 @@ export const checkSetup = async (
                 );
             }
         });
+
+    await checkImplementation(
+        provider,
+        contracts.yieldExtractor.proxy,
+        contracts.yieldExtractor.implementation,
+    );
+    const yieldExtractorContract = YieldExtractor__factory.connect(
+        contracts.yieldExtractor.proxy,
+        provider,
+    );
+    const hasYieldPublisher = await yieldExtractorContract.hasRole(
+        ROLES.YIELD_PUBLISHER,
+        yieldPublisher,
+    );
+    if (!hasYieldPublisher) {
+        warning(
+            `YieldExtractor: expected address ${yieldPublisher} to have YIELD_PUBLISHER (AccessControl is not enumerable on this contract).`,
+        );
+    }
 
     await checkImplementation(provider, contracts.swapper.proxy, contracts.swapper.implementation);
 
@@ -170,7 +191,7 @@ export const checkSetup = async (
         });
         await yelayLiteVault.yieldExtractor().then((r) => {
             if (r.toLowerCase() !== yieldExtractor.toLowerCase()) {
-                warning(`YieldExtractor mismatch. Expected: ${owner}. Actual: ${r}`);
+                warning(`YieldExtractor mismatch. Expected: ${yieldExtractor}. Actual: ${r}`);
             }
         });
 

--- a/scripts/utils/getters.ts
+++ b/scripts/utils/getters.ts
@@ -38,6 +38,7 @@ export const getFundsFacetSelectors = () => {
         'strategyRewards',
         'deposit',
         'redeem',
+        'claimAndRedeem',
         'migratePosition',
         'managedDeposit',
         'managedWithdraw',

--- a/scripts/versions/deploy-v3.1.ts
+++ b/scripts/versions/deploy-v3.1.ts
@@ -1,0 +1,54 @@
+import { ethers, upgrades } from 'hardhat';
+import { deployFundsFacet } from '../utils/deploy';
+import fs from 'fs';
+import path from 'path';
+import { getContractsPath } from '../utils/getters';
+import { isTesting } from '../utils/common';
+
+async function main() {
+    const merklDistributor = ''; //TODO set
+
+    const [deployer] = await ethers.getSigners();
+    const chainId = Number((await deployer.provider!.getNetwork()).chainId);
+    const testing = isTesting();
+    const deploymentPath = getContractsPath(chainId, testing);
+
+    const deploymentData = JSON.parse(fs.readFileSync(path.resolve(deploymentPath), 'utf8'));
+
+    console.log('Deploying funds facet...');
+    const fundsFacet = await deployFundsFacet(
+        deployer,
+        deploymentData.swapper.proxy,
+        merklDistributor,
+    );
+    console.log('FundsFacet deployed at:', fundsFacet);
+    deploymentData.fundsFacet = fundsFacet;
+
+    console.log('Deploying yield extractor implementation...');
+    const yieldExtractorFactory = await ethers.getContractFactory('YieldExtractor', deployer);
+    const yieldExtractorImplementationResult =
+        await upgrades.deployImplementation(yieldExtractorFactory);
+    let yieldExtractorImplementation: string;
+    if (typeof yieldExtractorImplementationResult === 'string') {
+        yieldExtractorImplementation = yieldExtractorImplementationResult;
+    } else {
+        const receipt = await yieldExtractorImplementationResult.wait();
+        if (!receipt?.contractAddress) {
+            throw new Error('Contract address not found in transaction receipt');
+        }
+        yieldExtractorImplementation = receipt.contractAddress;
+    }
+    console.log('YieldExtractor implementation deployed at:', yieldExtractorImplementation);
+    deploymentData.yieldExtractor.implementation = yieldExtractorImplementation;
+
+    fs.writeFileSync(path.resolve(deploymentPath), JSON.stringify(deploymentData, null, 4));
+}
+
+main()
+    .then(() => {
+        console.log('Ready');
+    })
+    .catch((e) => {
+        console.error(e);
+        process.exit(1);
+    });

--- a/src/YieldExtractor.sol
+++ b/src/YieldExtractor.sol
@@ -15,6 +15,7 @@ import {LibErrors} from "src/libraries/LibErrors.sol";
 import {LibRoles} from "src/libraries/LibRoles.sol";
 
 import {IFundsFacet} from "src/interfaces/IFundsFacet.sol";
+import {IYieldExtractor, ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 
 /**
  * @title YieldExtractor
@@ -36,6 +37,7 @@ import {IFundsFacet} from "src/interfaces/IFundsFacet.sol";
  * - Upgradeable contract design
  */
 contract YieldExtractor is
+    IYieldExtractor,
     PausableUpgradeable,
     ERC1155HolderUpgradeable,
     AccessControlDefaultAdminRulesUpgradeable,
@@ -44,22 +46,6 @@ contract YieldExtractor is
     using SafeERC20 for IERC20;
 
     uint256 constant YIELD_PROJECT_ID = 0;
-
-    /**
-     * @notice Request data structure for claiming yield
-     * @param yelayLiteVault Address of the YelayLite vault contract
-     * @param projectId ID of the project in the vault
-     * @param cycle Yield cycle number
-     * @param yieldSharesTotal Total amount of yield shares to be claimed
-     * @param proof Merkle proof array for verification
-     */
-    struct ClaimRequest {
-        address yelayLiteVault;
-        uint256 projectId;
-        uint256 cycle;
-        uint256 yieldSharesTotal;
-        bytes32[] proof;
-    }
 
     /**
      * @notice Merkle tree root data structure
@@ -172,7 +158,7 @@ contract YieldExtractor is
      */
     function claim(ClaimRequest[] calldata data) external whenNotPaused {
         for (uint256 i; i < data.length; ++i) {
-            uint256 toClaim = _processClaimRequest(data[i], i);
+            uint256 toClaim = _processClaimRequest(data[i], i, msg.sender);
 
             IFundsFacet(data[i].yelayLiteVault).redeem(toClaim, YIELD_PROJECT_ID, msg.sender);
 
@@ -185,23 +171,43 @@ contract YieldExtractor is
      * @param data Claim request
      */
     function transform(ClaimRequest calldata data) external whenNotPaused {
-        uint256 toClaim = _processClaimRequest(data, 0);
+        uint256 toClaim = _processClaimRequest(data, 0, msg.sender);
 
         IFundsFacet(data.yelayLiteVault).transformYieldShares(data.projectId, toClaim, msg.sender);
 
         emit LibEvents.YieldTransformed(msg.sender, data.yelayLiteVault, data.projectId, data.cycle, toClaim);
     }
 
-    function _processClaimRequest(ClaimRequest memory data, uint256 index) internal returns (uint256 toClaim) {
-        bytes32 leaf = _getLeaf(data, msg.sender);
+    /**
+     * @notice Transform yield shares to project shares on behalf of a user
+     * @dev Callable only by the vault (data.yelayLiteVault)
+     * @param data Claim request
+     * @param user Owner of the shares to transform
+     * @return toClaim The amount of shares transformed
+     */
+    function transformFor(ClaimRequest calldata data, address user) external whenNotPaused returns (uint256 toClaim) {
+        require(msg.sender == data.yelayLiteVault, LibErrors.OnlyYelayLiteVault());
+
+        toClaim = _processClaimRequest(data, 0, user);
+
+        IFundsFacet(data.yelayLiteVault).transformYieldShares(data.projectId, toClaim, user);
+
+        emit LibEvents.YieldTransformed(user, data.yelayLiteVault, data.projectId, data.cycle, toClaim);
+    }
+
+    function _processClaimRequest(ClaimRequest memory data, uint256 index, address user)
+        internal
+        returns (uint256 toClaim)
+    {
+        bytes32 leaf = _getLeaf(data, user);
         require(!isLeafClaimed[leaf], LibErrors.ProofAlreadyClaimed(index));
         require(_verify(data, leaf), LibErrors.InvalidProof(index));
 
-        isLeafClaimed[leaf] = true;
-
-        uint256 alreadyClaimed = yieldSharesClaimed[msg.sender][data.yelayLiteVault][data.projectId];
+        uint256 alreadyClaimed = yieldSharesClaimed[user][data.yelayLiteVault][data.projectId];
         toClaim = data.yieldSharesTotal - alreadyClaimed;
-        yieldSharesClaimed[msg.sender][data.yelayLiteVault][data.projectId] = data.yieldSharesTotal;
+
+        yieldSharesClaimed[user][data.yelayLiteVault][data.projectId] = data.yieldSharesTotal;
+        isLeafClaimed[leaf] = true;
     }
 
     /**

--- a/src/YieldExtractor.sol
+++ b/src/YieldExtractor.sol
@@ -15,7 +15,7 @@ import {LibErrors} from "src/libraries/LibErrors.sol";
 import {LibRoles} from "src/libraries/LibRoles.sol";
 
 import {IFundsFacet} from "src/interfaces/IFundsFacet.sol";
-import {IYieldExtractor, ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
+import {IYieldExtractor, ClaimRequest, Root} from "src/interfaces/IYieldExtractor.sol";
 
 /**
  * @title YieldExtractor
@@ -46,16 +46,6 @@ contract YieldExtractor is
     using SafeERC20 for IERC20;
 
     uint256 constant YIELD_PROJECT_ID = 0;
-
-    /**
-     * @notice Merkle tree root data structure
-     * @param hash Merkle root hash
-     * @param blockNumber Block number at which yield share values were calculated
-     */
-    struct Root {
-        bytes32 hash;
-        uint256 blockNumber;
-    }
 
     /**
      * @notice Current cycle count for yield distributions per vault
@@ -108,25 +98,17 @@ contract YieldExtractor is
         return super.supportsInterface(interfaceId);
     }
 
-    /**
-     * @notice Pause claiming
-     */
+    /// @inheritdoc IYieldExtractor
     function pause() external onlyRole(LibRoles.PAUSER) {
         _pause();
     }
 
-    /**
-     * @notice Unpause claiming
-     */
+    /// @inheritdoc IYieldExtractor
     function unpause() external onlyRole(LibRoles.UNPAUSER) {
         _unpause();
     }
 
-    /**
-     * @notice Add a Merkle tree root for a new cycle for a given vault
-     * @param root Root to add
-     * @param yelayLiteVault Address of the vault
-     */
+    /// @inheritdoc IYieldExtractor
     function addTreeRoot(Root memory root, address yelayLiteVault) external onlyRole(LibRoles.YIELD_PUBLISHER) {
         cycleCount[yelayLiteVault]++;
         roots[yelayLiteVault][cycleCount[yelayLiteVault]] = root;
@@ -134,12 +116,7 @@ contract YieldExtractor is
         emit LibEvents.PoolRootAdded(yelayLiteVault, cycleCount[yelayLiteVault], root.hash, root.blockNumber);
     }
 
-    /**
-     * @notice Update existing root for a given cycle for a given vault
-     * @param root New root
-     * @param cycle Cycle to update
-     * @param yelayLiteVault Address of the vault
-     */
+    /// @inheritdoc IYieldExtractor
     function updateTreeRoot(Root memory root, uint256 cycle, address yelayLiteVault)
         external
         onlyRole(LibRoles.YIELD_PUBLISHER)
@@ -152,10 +129,7 @@ contract YieldExtractor is
         emit LibEvents.PoolRootUpdated(yelayLiteVault, cycle, previousRoot.hash, root.hash, root.blockNumber);
     }
 
-    /**
-     * @notice Claim incentives by submitting a Merkle proof
-     * @param data Array of claim requests
-     */
+    /// @inheritdoc IYieldExtractor
     function claim(ClaimRequest[] calldata data) external whenNotPaused {
         for (uint256 i; i < data.length; ++i) {
             uint256 toClaim = _processClaimRequest(data[i], i, msg.sender);
@@ -166,10 +140,7 @@ contract YieldExtractor is
         }
     }
 
-    /**
-     * @notice Transform incentives to projectId shares by submitting a Merkle proof
-     * @param data Claim request
-     */
+    /// @inheritdoc IYieldExtractor
     function transform(ClaimRequest calldata data) external whenNotPaused {
         uint256 toClaim = _processClaimRequest(data, 0, msg.sender);
 
@@ -178,13 +149,7 @@ contract YieldExtractor is
         emit LibEvents.YieldTransformed(msg.sender, data.yelayLiteVault, data.projectId, data.cycle, toClaim);
     }
 
-    /**
-     * @notice Transform yield shares to project shares on behalf of a user
-     * @dev Callable only by the vault (data.yelayLiteVault)
-     * @param data Claim request
-     * @param user Owner of the shares to transform
-     * @return toClaim The amount of shares transformed
-     */
+    /// @inheritdoc IYieldExtractor
     function transformFor(ClaimRequest calldata data, address user) external whenNotPaused returns (uint256 toClaim) {
         require(msg.sender == data.yelayLiteVault, LibErrors.OnlyYelayLiteVault());
 
@@ -210,11 +175,7 @@ contract YieldExtractor is
         isLeafClaimed[leaf] = true;
     }
 
-    /**
-     * @notice Verify a Merkle proof for given claim request
-     * @param data Claim request to verify
-     * @param user User address for claim request
-     */
+    /// @inheritdoc IYieldExtractor
     function verify(ClaimRequest memory data, address user) external view returns (bool) {
         return _verify(data, _getLeaf(data, user));
     }

--- a/src/YieldExtractor.sol
+++ b/src/YieldExtractor.sol
@@ -169,7 +169,7 @@ contract YieldExtractor is
         require(_verify(data, leaf), LibErrors.InvalidProof(index));
 
         isLeafClaimed[leaf] = true;
-        
+
         uint256 alreadyClaimed = yieldSharesClaimed[user][data.yelayLiteVault][data.projectId];
         toClaim = data.yieldSharesTotal - alreadyClaimed;
 

--- a/src/YieldExtractor.sol
+++ b/src/YieldExtractor.sol
@@ -168,11 +168,12 @@ contract YieldExtractor is
         require(!isLeafClaimed[leaf], LibErrors.ProofAlreadyClaimed(index));
         require(_verify(data, leaf), LibErrors.InvalidProof(index));
 
+        isLeafClaimed[leaf] = true;
+        
         uint256 alreadyClaimed = yieldSharesClaimed[user][data.yelayLiteVault][data.projectId];
         toClaim = data.yieldSharesTotal - alreadyClaimed;
 
         yieldSharesClaimed[user][data.yelayLiteVault][data.projectId] = data.yieldSharesTotal;
-        isLeafClaimed[leaf] = true;
     }
 
     /// @inheritdoc IYieldExtractor

--- a/src/YieldExtractor.sol
+++ b/src/YieldExtractor.sol
@@ -150,10 +150,10 @@ contract YieldExtractor is
     }
 
     /// @inheritdoc IYieldExtractor
-    function transformFor(ClaimRequest calldata data, address user) external whenNotPaused returns (uint256 toClaim) {
+    function transformFor(ClaimRequest calldata data, address user) external whenNotPaused {
         require(msg.sender == data.yelayLiteVault, LibErrors.OnlyYelayLiteVault());
 
-        toClaim = _processClaimRequest(data, 0, user);
+        uint256 toClaim = _processClaimRequest(data, 0, user);
 
         IFundsFacet(data.yelayLiteVault).transformYieldShares(data.projectId, toClaim, user);
 

--- a/src/facets/FundsFacet.sol
+++ b/src/facets/FundsFacet.sol
@@ -170,7 +170,7 @@ contract FundsFacet is RoleCheck, PausableCheck, ERC1155SupplyUpgradeable, IFund
 
         uint256 withdrawn;
         for (uint256 i; i < sM.withdrawQueue.length; i++) {
-            uint256 toWithdraw = assets - withdrawn;
+            uint256 toWithdraw = assets.zeroFloorSub(withdrawn);
             if (toWithdraw <= WITHDRAW_MARGIN) break;
             uint256 assetBalance = IStrategyBase(sM.activeStrategies[sM.withdrawQueue[i]].adapter).assetBalance(
                 address(this), sM.activeStrategies[sM.withdrawQueue[i]].supplement

--- a/src/facets/FundsFacet.sol
+++ b/src/facets/FundsFacet.sol
@@ -22,6 +22,7 @@ import {LibManagement} from "src/libraries/LibManagement.sol";
 import {LibRoles} from "src/libraries/LibRoles.sol";
 import {LibEvents} from "src/libraries/LibEvents.sol";
 import {LibErrors} from "src/libraries/LibErrors.sol";
+import {IYieldExtractor, ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 
 /**
  * @title FundsFacet
@@ -158,6 +159,31 @@ contract FundsFacet is RoleCheck, PausableCheck, ERC1155SupplyUpgradeable, IFund
 
     /// @inheritdoc IFundsFacet
     function redeem(uint256 shares, uint256 projectId, address receiver) external notPaused returns (uint256 assets) {
+        return _redeem(shares, projectId, receiver);
+    }
+
+    /// @inheritdoc IFundsFacet
+    function claimAndRedeem(ClaimRequest calldata data, uint256 shares, address receiver)
+        external
+        notPaused
+        returns (uint256 assets)
+    {
+        LibFunds.FundsStorage storage sF = LibFunds._getFundsStorage();
+        require(data.yelayLiteVault == address(this), LibErrors.InvalidClaimVault());
+
+        IYieldExtractor(sF.yieldExtractor).transformFor(data, msg.sender);
+
+        return _redeem(shares, data.projectId, receiver);
+    }
+
+    /**
+     * @dev Internal redeem logic
+     * @param shares The amount of shares to redeem.
+     * @param projectId The project ID.
+     * @param receiver The address of the receiver.
+     * @return assets The amount of assets redeemed.
+     */
+    function _redeem(uint256 shares, uint256 projectId, address receiver) internal returns (uint256 assets) {
         LibFunds.FundsStorage storage sF = LibFunds._getFundsStorage();
         LibManagement.ManagementStorage storage sM = LibManagement._getManagementStorage();
 

--- a/src/interfaces/IFundsFacet.sol
+++ b/src/interfaces/IFundsFacet.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.28;
 
 import {IERC1155} from "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
+import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 import {IERC1155MetadataURI} from "@openzeppelin/contracts/token/ERC1155/extensions/IERC1155MetadataURI.sol";
 import {Reward} from "./IStrategyBase.sol";
 import {SwapArgs} from "./ISwapper.sol";
@@ -122,6 +123,17 @@ interface IFundsFacet is IERC1155, IERC1155MetadataURI {
      * @param receiver The address that will receive the transformed shares
      */
     function transformYieldShares(uint256 projectId, uint256 shares, address receiver) external;
+
+    /**
+     * @dev Claim yield via transform and redeem in one call.
+     * @param data Claim request.
+     * @param shares Amount of shares to redeem (independent of claim amount).
+     * @param receiver The address of the receiver.
+     * @return assets The amount of assets redeemed.
+     */
+    function claimAndRedeem(ClaimRequest calldata data, uint256 shares, address receiver)
+        external
+        returns (uint256 assets);
 
     /**
      * @notice Converts a given amount of assets to the equivalent amount of shares

--- a/src/interfaces/IYieldExtractor.sol
+++ b/src/interfaces/IYieldExtractor.sol
@@ -109,9 +109,8 @@ interface IYieldExtractor {
      * @dev Callable only by the vault (data.yelayLiteVault).
      * @param data Claim request.
      * @param user Owner of the shares to transform.
-     * @return toClaim The amount of shares transformed.
      */
-    function transformFor(ClaimRequest calldata data, address user) external returns (uint256 toClaim);
+    function transformFor(ClaimRequest calldata data, address user) external;
 
     /**
      * @dev Verifies a Merkle proof for a given claim request.

--- a/src/interfaces/IYieldExtractor.sol
+++ b/src/interfaces/IYieldExtractor.sol
@@ -17,13 +17,107 @@ struct ClaimRequest {
     bytes32[] proof;
 }
 
+/**
+ * @notice Merkle tree root data structure
+ * @param hash Merkle root hash
+ * @param blockNumber Block number at which yield share values were calculated
+ */
+struct Root {
+    bytes32 hash;
+    uint256 blockNumber;
+}
+
 interface IYieldExtractor {
     /**
-     * @notice Transform yield shares to project shares on behalf of a user
-     * @dev Callable only by the vault (data.yelayLiteVault)
-     * @param data Claim request
-     * @param user Owner of the shares to transform
-     * @return toClaim The amount of shares transformed
+     * @dev Returns the current cycle count for yield distributions for a given vault.
+     * @param yelayLiteVault Address of the vault.
+     * @return The current cycle count.
+     */
+    function cycleCount(address yelayLiteVault) external view returns (uint256);
+
+    /**
+     * @dev Returns the Merkle tree root for a given cycle and vault.
+     * @param yelayLiteVault Address of the vault.
+     * @param cycle The cycle number.
+     * @return hash The Merkle root hash.
+     * @return blockNumber The block number at which yield share values were calculated.
+     */
+    function roots(address yelayLiteVault, uint256 cycle) external view returns (bytes32 hash, uint256 blockNumber);
+
+    /**
+     * @dev Tracks whether a specific leaf has been claimed.
+     * @param leaf The leaf hash.
+     * @return True if the leaf has been claimed.
+     */
+    function isLeafClaimed(bytes32 leaf) external view returns (bool);
+
+    /**
+     * @dev Tracks yield shares claimed by users.
+     * @param user The user address.
+     * @param yelayLiteVault Address of the vault.
+     * @param projectId The project ID.
+     * @return The amount of yield shares claimed.
+     */
+    function yieldSharesClaimed(address user, address yelayLiteVault, uint256 projectId)
+        external
+        view
+        returns (uint256);
+
+    /**
+     * @dev Pauses claiming.
+     * @dev Callable by PAUSER.
+     */
+    function pause() external;
+
+    /**
+     * @dev Unpauses claiming.
+     * @dev Callable by UNPAUSER.
+     */
+    function unpause() external;
+
+    /**
+     * @dev Adds a Merkle tree root for a new cycle for a given vault.
+     * @dev Callable by YIELD_PUBLISHER.
+     * @param root Root to add.
+     * @param yelayLiteVault Address of the vault.
+     */
+    function addTreeRoot(Root memory root, address yelayLiteVault) external;
+
+    /**
+     * @dev Updates existing root for a given cycle for a given vault.
+     * @dev Callable by YIELD_PUBLISHER.
+     * @param root New root.
+     * @param cycle Cycle to update.
+     * @param yelayLiteVault Address of the vault.
+     */
+    function updateTreeRoot(Root memory root, uint256 cycle, address yelayLiteVault) external;
+
+    /**
+     * @dev Claims incentives by submitting Merkle proofs.
+     * @param data Array of claim requests.
+     */
+    function claim(ClaimRequest[] calldata data) external;
+
+    /**
+     * @dev Transforms incentives to project shares by submitting a Merkle proof.
+     * @param data Claim request.
+     */
+    function transform(ClaimRequest calldata data) external;
+
+    /**
+     * @dev Transforms yield shares to project shares on behalf of a user.
+     * @dev Callable only by the vault (data.yelayLiteVault).
+     * @param data Claim request.
+     * @param user Owner of the shares to transform.
+     * @return toClaim The amount of shares transformed.
      */
     function transformFor(ClaimRequest calldata data, address user) external returns (uint256 toClaim);
+
+    /**
+     * @dev Verifies a Merkle proof for a given claim request.
+     * @param data Claim request to verify.
+     * @param user User address for claim request.
+     * @return True if the proof is valid.
+     */
+    function verify(ClaimRequest memory data, address user) external view returns (bool);
 }

--- a/src/interfaces/IYieldExtractor.sol
+++ b/src/interfaces/IYieldExtractor.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.28;
+
+/**
+ * @notice Request data structure for claiming yield
+ * @param yelayLiteVault Address of the YelayLite vault contract
+ * @param projectId ID of the project in the vault
+ * @param cycle Yield cycle number
+ * @param yieldSharesTotal Total amount of yield shares to be claimed
+ * @param proof Merkle proof array for verification
+ */
+struct ClaimRequest {
+    address yelayLiteVault;
+    uint256 projectId;
+    uint256 cycle;
+    uint256 yieldSharesTotal;
+    bytes32[] proof;
+}
+
+interface IYieldExtractor {
+    /**
+     * @notice Transform yield shares to project shares on behalf of a user
+     * @dev Callable only by the vault (data.yelayLiteVault)
+     * @param data Claim request
+     * @param user Owner of the shares to transform
+     * @return toClaim The amount of shares transformed
+     */
+    function transformFor(ClaimRequest calldata data, address user) external returns (uint256 toClaim);
+}

--- a/src/libraries/LibErrors.sol
+++ b/src/libraries/LibErrors.sol
@@ -99,6 +99,11 @@ library LibErrors {
      */
     error OnlyYieldExtractor();
 
+    /**
+     * @dev Claim request must be for the vault making the call
+     */
+    error InvalidClaimVault();
+
     // ===================== SwapWrapper ================================
     /**
      * @dev The token is not WETH.
@@ -212,6 +217,11 @@ library LibErrors {
     error LockModeMismatch(address vault, uint256 projectId, uint256 lockMode);
 
     // ===================== YieldExtractor ================================
+
+    /**
+     * @dev transformFor can only be called by the vault
+     */
+    error OnlyYelayLiteVault();
 
     /**
      * @notice Thrown when a Merkle proof is invalid

--- a/src/plugins/ERC4626Plugin.sol
+++ b/src/plugins/ERC4626Plugin.sol
@@ -11,8 +11,7 @@ import {Math} from "@openzeppelin/contracts/utils/math/Math.sol";
 import {FixedPointMathLib} from "@solady/utils/FixedPointMathLib.sol";
 
 import {IYelayLiteVault} from "src/interfaces/IYelayLiteVault.sol";
-import {YieldExtractor} from "src/YieldExtractor.sol";
-import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
+import {ClaimRequest, IYieldExtractor} from "src/interfaces/IYieldExtractor.sol";
 import {LibErrors} from "src/libraries/LibErrors.sol";
 import {LibEvents} from "src/libraries/LibEvents.sol";
 
@@ -29,7 +28,7 @@ contract ERC4626Plugin is ERC1155HolderUpgradeable, ERC4626Upgradeable {
     // ============ Constants ============
 
     /// @notice The yield extractor contract used for yield accrual
-    YieldExtractor public immutable yieldExtractor;
+    IYieldExtractor public immutable yieldExtractor;
 
     // ============ State Variables ============
 
@@ -49,7 +48,7 @@ contract ERC4626Plugin is ERC1155HolderUpgradeable, ERC4626Upgradeable {
      * @param _yieldExtractor The address of the yield extractor contract
      */
     constructor(address _yieldExtractor) {
-        yieldExtractor = YieldExtractor(_yieldExtractor);
+        yieldExtractor = IYieldExtractor(_yieldExtractor);
     }
 
     // ============ Initialization ============

--- a/src/plugins/ERC4626Plugin.sol
+++ b/src/plugins/ERC4626Plugin.sol
@@ -12,6 +12,7 @@ import {FixedPointMathLib} from "@solady/utils/FixedPointMathLib.sol";
 
 import {IYelayLiteVault} from "src/interfaces/IYelayLiteVault.sol";
 import {YieldExtractor} from "src/YieldExtractor.sol";
+import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 import {LibErrors} from "src/libraries/LibErrors.sol";
 import {LibEvents} from "src/libraries/LibEvents.sol";
 
@@ -82,7 +83,7 @@ contract ERC4626Plugin is ERC1155HolderUpgradeable, ERC4626Upgradeable {
      * @notice Accrues yield by processing a claim request through the yield extractor
      * @param data The claim request data containing yield extraction parameters
      */
-    function accrue(YieldExtractor.ClaimRequest calldata data) external {
+    function accrue(ClaimRequest calldata data) external {
         yieldExtractor.transform(data);
     }
 

--- a/test/Utils.sol
+++ b/test/Utils.sol
@@ -72,7 +72,7 @@ library Utils {
     }
 
     function fundsFacetSelectors() internal pure returns (bytes4[] memory) {
-        bytes4[] memory selectors = new bytes4[](30);
+        bytes4[] memory selectors = new bytes4[](31);
         selectors[0] = bytes4(keccak256("totalSupply()"));
         selectors[1] = bytes4(keccak256("totalSupply(uint256)"));
         selectors[2] = FundsFacet.lastTotalAssets.selector;
@@ -88,21 +88,22 @@ library Utils {
         selectors[12] = FundsFacet.deposit.selector;
         selectors[13] = FundsFacet.redeem.selector;
         selectors[14] = FundsFacet.migratePosition.selector;
-        selectors[15] = FundsFacet.managedDeposit.selector;
-        selectors[16] = FundsFacet.managedWithdraw.selector;
-        selectors[17] = FundsFacet.reallocate.selector;
-        selectors[18] = FundsFacet.swapRewards.selector;
-        selectors[19] = FundsFacet.compoundUnderlyingReward.selector;
-        selectors[20] = FundsFacet.accrueFee.selector;
-        selectors[21] = FundsFacet.claimStrategyRewards.selector;
-        selectors[22] = FundsFacet.claimMerklRewards.selector;
-        selectors[23] = ERC1155Upgradeable.balanceOf.selector;
-        selectors[24] = ERC1155Upgradeable.uri.selector;
-        selectors[25] = FundsFacet.transformYieldShares.selector;
-        selectors[26] = FundsFacet.convertToShares.selector;
-        selectors[27] = FundsFacet.convertToAssets.selector;
-        selectors[28] = FundsFacet.previewRedeem.selector;
-        selectors[29] = FundsFacet.previewWithdraw.selector;
+        selectors[15] = FundsFacet.claimAndRedeem.selector;
+        selectors[16] = FundsFacet.managedDeposit.selector;
+        selectors[17] = FundsFacet.managedWithdraw.selector;
+        selectors[18] = FundsFacet.reallocate.selector;
+        selectors[19] = FundsFacet.swapRewards.selector;
+        selectors[20] = FundsFacet.compoundUnderlyingReward.selector;
+        selectors[21] = FundsFacet.accrueFee.selector;
+        selectors[22] = FundsFacet.claimStrategyRewards.selector;
+        selectors[23] = FundsFacet.claimMerklRewards.selector;
+        selectors[24] = ERC1155Upgradeable.balanceOf.selector;
+        selectors[25] = ERC1155Upgradeable.uri.selector;
+        selectors[26] = FundsFacet.transformYieldShares.selector;
+        selectors[27] = FundsFacet.convertToShares.selector;
+        selectors[28] = FundsFacet.convertToAssets.selector;
+        selectors[29] = FundsFacet.previewRedeem.selector;
+        selectors[30] = FundsFacet.previewWithdraw.selector;
         return selectors;
     }
 

--- a/test/mocks/MockYieldExtractor.sol
+++ b/test/mocks/MockYieldExtractor.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.28;
 
 import {IFundsFacet} from "src/interfaces/IFundsFacet.sol";
 import {YieldExtractor} from "src/YieldExtractor.sol";
+import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 
 import {ERC1155Holder} from "@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol";
 
@@ -15,11 +16,11 @@ contract MockYieldExtractor is ERC1155Holder {
         toClaim = value;
     }
 
-    function claim(YieldExtractor.ClaimRequest[] calldata data) external {
+    function claim(ClaimRequest[] calldata data) external {
         IFundsFacet(data[0].yelayLiteVault).redeem(toClaim, YIELD_PROJECT_ID, msg.sender);
     }
 
-    function transform(YieldExtractor.ClaimRequest calldata data) external {
+    function transform(ClaimRequest calldata data) external {
         IFundsFacet(data.yelayLiteVault).transformYieldShares(data.projectId, toClaim, msg.sender);
     }
 }

--- a/test/mocks/MockYieldExtractor.sol
+++ b/test/mocks/MockYieldExtractor.sol
@@ -23,4 +23,8 @@ contract MockYieldExtractor is ERC1155Holder {
     function transform(ClaimRequest calldata data) external {
         IFundsFacet(data.yelayLiteVault).transformYieldShares(data.projectId, toClaim, msg.sender);
     }
+
+    function transformFor(ClaimRequest calldata data, address user) external {
+        IFundsFacet(data.yelayLiteVault).transformYieldShares(data.projectId, toClaim, user);
+    }
 }

--- a/test/units/ERC4626Plugin.t.sol
+++ b/test/units/ERC4626Plugin.t.sol
@@ -7,6 +7,7 @@ import {ERC4626Upgradeable} from "@openzeppelin-upgradeable/contracts/token/ERC2
 
 import {ERC4626PluginFactory} from "src/plugins/ERC4626PluginFactory.sol";
 import {YieldExtractor} from "src/YieldExtractor.sol";
+import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 
 import {ERC4626Plugin} from "src/plugins/ERC4626Plugin.sol";
 import {IYelayLiteVault} from "src/interfaces/IYelayLiteVault.sol";
@@ -112,7 +113,7 @@ contract ERC4626PluginTest is Test {
         uint256 yieldShares = yelayLiteVault.balanceOf(address(yieldExtractor), 0);
         uint256 yieldToGenerate = yieldShares / 2;
         yieldExtractor.setToClaim(yieldToGenerate);
-        erc4626Plugin.accrue(YieldExtractor.ClaimRequest(address(yelayLiteVault), PROJECT_ID, 0, 0, new bytes32[](0)));
+        erc4626Plugin.accrue(ClaimRequest(address(yelayLiteVault), PROJECT_ID, 0, 0, new bytes32[](0)));
         return yieldToGenerate;
     }
 

--- a/test/units/FundsFacet.t.sol
+++ b/test/units/FundsFacet.t.sol
@@ -12,6 +12,7 @@ import {LibEvents} from "src/libraries/LibEvents.sol";
 
 import {StrategyData} from "src/interfaces/IManagementFacet.sol";
 import {StrategyArgs} from "src/interfaces/IFundsFacet.sol";
+import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 
 import {MockStrategy, MockProtocol} from "test/mocks/MockStrategy.sol";
 import {MockYieldExtractor} from "test/mocks/MockYieldExtractor.sol";
@@ -216,6 +217,163 @@ contract FundsFacetTest is Test {
         vm.prank(address(yieldExtractor));
         vm.expectRevert(abi.encodeWithSelector(LibErrors.PositionMigrationForbidden.selector));
         yelayLiteVault.transformYieldShares(100500, 100, user);
+    }
+
+    // ========== Tests for claimAndRedeem ==========
+
+    function _claimRedeemYieldSetup()
+        internal
+        returns (uint256 userShares_, uint256 yieldShares_, uint256 yieldAmount_, uint256 toDeposit_)
+    {
+        _addStrategy();
+        toDeposit_ = 1000e18;
+        deal(address(underlyingAsset), user, 10_000e18);
+        vm.prank(user);
+        userShares_ = yelayLiteVault.deposit(toDeposit_, projectId, user);
+        yieldAmount_ = toDeposit_ * 2 / 10;
+        deal(address(underlyingAsset), address(mockProtocol), yieldAmount_);
+        mockProtocol.setAssetBalance(address(yelayLiteVault), toDeposit_ + yieldAmount_);
+        yelayLiteVault.accrueFee();
+        yieldShares_ = yelayLiteVault.balanceOf(address(yieldExtractor), 0);
+        assertGt(yieldShares_, 0);
+    }
+
+    function test_claimAndRedeem_success() external {
+        (uint256 userShares, uint256 yieldShares, uint256 yieldAmount, uint256 toDeposit) = _claimRedeemYieldSetup();
+        uint256 toClaim = yieldShares;
+        yieldExtractor.setToClaim(toClaim);
+
+        address receiver = user2;
+        uint256 sharesToRedeem = yieldShares;
+        ClaimRequest memory data = ClaimRequest({
+            yelayLiteVault: address(yelayLiteVault),
+            projectId: projectId,
+            cycle: 1,
+            yieldSharesTotal: yieldShares,
+            proof: new bytes32[](0)
+        });
+
+        uint256 receiverBalanceBefore = underlyingAsset.balanceOf(receiver);
+        uint256 totalSupplyBefore = yelayLiteVault.totalSupply();
+        uint256 expectedRedeemAssets = yelayLiteVault.convertToAssets(sharesToRedeem);
+
+        assertEq(yelayLiteVault.totalAssets(), toDeposit + yieldAmount);
+
+        vm.prank(user);
+        uint256 assets = yelayLiteVault.claimAndRedeem(data, sharesToRedeem, receiver);
+
+        assertEq(assets, expectedRedeemAssets);
+
+        // claimed: yield shares removed from extractor = toClaim (MockYieldExtractor.toClaim)
+        assertEq(yelayLiteVault.balanceOf(address(yieldExtractor), 0), yieldShares - toClaim);
+        // redeemed: burnt shares = shares passed into claimAndRedeem
+        assertEq(yelayLiteVault.totalSupply(), totalSupplyBefore - sharesToRedeem);
+
+        assertEq(underlyingAsset.balanceOf(receiver), receiverBalanceBefore + assets);
+        assertEq(yelayLiteVault.balanceOf(user, projectId), userShares);
+        assertEq(yelayLiteVault.balanceOf(user, 0), 0);
+    }
+
+    /// @dev Claim (transform) moves full yield shares to user; redeem burns only part — leftover stays on projectId.
+    function test_claimAndRedeem_claimedGreaterThanRedeemed() external {
+        (uint256 userShares, uint256 yieldShares, uint256 yieldAmount, uint256 toDeposit) = _claimRedeemYieldSetup();
+        uint256 toClaim = yieldShares;
+        yieldExtractor.setToClaim(toClaim);
+        uint256 sharesToRedeem = yieldShares / 2;
+        assertGt(sharesToRedeem, 0);
+
+        ClaimRequest memory data = ClaimRequest({
+            yelayLiteVault: address(yelayLiteVault),
+            projectId: projectId,
+            cycle: 1,
+            yieldSharesTotal: yieldShares,
+            proof: new bytes32[](0)
+        });
+
+        uint256 totalSupplyBefore = yelayLiteVault.totalSupply();
+        uint256 expectedRedeemAssets = yelayLiteVault.convertToAssets(sharesToRedeem);
+        assertEq(yelayLiteVault.totalAssets(), toDeposit + yieldAmount);
+
+        vm.prank(user);
+        uint256 assets = yelayLiteVault.claimAndRedeem(data, sharesToRedeem, user);
+
+        assertEq(assets, expectedRedeemAssets);
+        assertEq(yelayLiteVault.balanceOf(address(yieldExtractor), 0), yieldShares - toClaim);
+        assertEq(yelayLiteVault.totalSupply(), totalSupplyBefore - sharesToRedeem);
+        assertEq(yelayLiteVault.balanceOf(user, projectId), userShares + toClaim - sharesToRedeem);
+        assertEq(yelayLiteVault.balanceOf(user, 0), 0);
+    }
+
+    /// @dev Redeem burns more shares than transform minted — difference is taken from the user's prior deposit.
+    function test_claimAndRedeem_redeemedGreaterThanClaimed() external {
+        (uint256 userShares, uint256 yieldShares, uint256 yieldAmount, uint256 toDeposit) = _claimRedeemYieldSetup();
+        uint256 toClaim = yieldShares / 2;
+        yieldExtractor.setToClaim(toClaim);
+        uint256 sharesToRedeem = yieldShares;
+        assertGt(toClaim, 0);
+        assertGt(sharesToRedeem, toClaim);
+        assertGe(userShares + toClaim, sharesToRedeem);
+
+        ClaimRequest memory data = ClaimRequest({
+            yelayLiteVault: address(yelayLiteVault),
+            projectId: projectId,
+            cycle: 1,
+            yieldSharesTotal: yieldShares,
+            proof: new bytes32[](0)
+        });
+
+        uint256 totalSupplyBefore = yelayLiteVault.totalSupply();
+        uint256 expectedRedeemAssets = yelayLiteVault.convertToAssets(sharesToRedeem);
+        assertEq(yelayLiteVault.totalAssets(), toDeposit + yieldAmount);
+
+        vm.prank(user);
+        uint256 assets = yelayLiteVault.claimAndRedeem(data, sharesToRedeem, user);
+
+        assertEq(assets, expectedRedeemAssets);
+        assertEq(yelayLiteVault.balanceOf(address(yieldExtractor), 0), yieldShares - toClaim);
+        assertEq(yelayLiteVault.totalSupply(), totalSupplyBefore - sharesToRedeem);
+        assertEq(yelayLiteVault.balanceOf(user, projectId), userShares + toClaim - sharesToRedeem);
+        assertEq(yelayLiteVault.balanceOf(user, 0), 0);
+    }
+
+    /// @dev Cannot redeem more shares on projectId than deposit + claimed amount.
+    function test_claimAndRedeem_revertsWhenRedeemExceedsDepositPlusClaimed() external {
+        (uint256 userShares, uint256 yieldShares,,) = _claimRedeemYieldSetup();
+        uint256 toClaim = yieldShares;
+        yieldExtractor.setToClaim(toClaim);
+        uint256 sharesToRedeem = userShares + toClaim + 1;
+
+        ClaimRequest memory data = ClaimRequest({
+            yelayLiteVault: address(yelayLiteVault),
+            projectId: projectId,
+            cycle: 1,
+            yieldSharesTotal: yieldShares,
+            proof: new bytes32[](0)
+        });
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(LibErrors.NotEnoughInternalFunds.selector));
+        yelayLiteVault.claimAndRedeem(data, sharesToRedeem, user);
+    }
+
+    function test_claimAndRedeem_invalidVault() external {
+        _addStrategy();
+        uint256 userBalance = 10_000e18;
+        deal(address(underlyingAsset), user, userBalance);
+        vm.prank(user);
+        yelayLiteVault.deposit(1000e18, projectId, user);
+
+        ClaimRequest memory data = ClaimRequest({
+            yelayLiteVault: address(0xdead),
+            projectId: projectId,
+            cycle: 1,
+            yieldSharesTotal: 100,
+            proof: new bytes32[](0)
+        });
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(LibErrors.InvalidClaimVault.selector));
+        yelayLiteVault.claimAndRedeem(data, 100, user);
     }
 
     // ========== Tests for convertToShares / convertToAssets ==========

--- a/test/units/YieldExtractor.t.sol
+++ b/test/units/YieldExtractor.t.sol
@@ -426,6 +426,56 @@ contract YieldExtractorTest is Test {
         assertEq(userSharesBefore + yieldTotal0, userSharesAfter);
     }
 
+    function test_transformFor_success() public {
+        bytes32[] memory proof = new bytes32[](1);
+        proof[0] = proof0;
+
+        uint256 yieldSharesBefore = mockVault0.totalSupply(0);
+        uint256 sharesBefore = mockVault0.totalSupply(projectId);
+        uint256 userSharesBefore = mockVault0.balanceOf(user, projectId);
+
+        ClaimRequest memory data = ClaimRequest({
+            yelayLiteVault: address(mockVault0),
+            projectId: projectId,
+            cycle: 1,
+            yieldSharesTotal: yieldTotal0,
+            proof: proof
+        });
+        vm.startPrank(yieldPublisher);
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
+        yieldExtractor.addTreeRoot(root0, address(mockVault0));
+        vm.stopPrank();
+
+        vm.prank(address(mockVault0));
+        vm.expectEmit(true, true, true, true);
+        emit LibEvents.YieldTransformed(user, data.yelayLiteVault, data.projectId, data.cycle, data.yieldSharesTotal);
+        yieldExtractor.transformFor(data, user);
+
+        assertEq(mockVault0.totalSupply(0), yieldSharesBefore - yieldTotal0);
+        assertEq(mockVault0.totalSupply(projectId), sharesBefore + yieldTotal0);
+        assertEq(mockVault0.balanceOf(user, projectId), userSharesBefore + yieldTotal0);
+    }
+
+    function test_transformFor_onlyVaultCanCall() public {
+        bytes32[] memory proof = new bytes32[](1);
+        proof[0] = proof0;
+        ClaimRequest memory data = ClaimRequest({
+            yelayLiteVault: address(mockVault0),
+            projectId: projectId,
+            cycle: 1,
+            yieldSharesTotal: yieldTotal0,
+            proof: proof
+        });
+        vm.startPrank(yieldPublisher);
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
+        yieldExtractor.addTreeRoot(root0, address(mockVault0));
+        vm.stopPrank();
+
+        vm.prank(user);
+        vm.expectRevert(abi.encodeWithSelector(LibErrors.OnlyYelayLiteVault.selector));
+        yieldExtractor.transformFor(data, user);
+    }
+
     function test_claim_twoCycles() public {
         bytes32[] memory proof = new bytes32[](1);
         ClaimRequest[] memory payload = new ClaimRequest[](1);

--- a/test/units/YieldExtractor.t.sol
+++ b/test/units/YieldExtractor.t.sol
@@ -15,6 +15,7 @@ import {LibErrors} from "src/libraries/LibErrors.sol";
 import {LibEvents} from "src/libraries/LibEvents.sol";
 import {LibRoles} from "src/libraries/LibRoles.sol";
 import {YieldExtractor} from "src/YieldExtractor.sol";
+import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
 import {MockToken} from "test/mocks/MockToken.sol";
 import {Utils} from "test/Utils.sol";
 
@@ -239,7 +240,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof0;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -257,7 +258,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof_fail;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -276,7 +277,7 @@ contract YieldExtractorTest is Test {
         proof[0] = proof0;
 
         // Replace with an invalid vault address
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: vault_fail,
             projectId: projectId,
             cycle: 1,
@@ -294,7 +295,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof0;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -314,7 +315,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof0;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -333,7 +334,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof0;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -351,7 +352,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof0;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 2,
@@ -369,7 +370,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof0;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -381,7 +382,7 @@ contract YieldExtractorTest is Test {
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
-        YieldExtractor.ClaimRequest[] memory payload = new YieldExtractor.ClaimRequest[](1);
+        ClaimRequest[] memory payload = new ClaimRequest[](1);
         payload[0] = data;
         vm.prank(user);
         vm.expectEmit(true, true, true, true);
@@ -399,7 +400,7 @@ contract YieldExtractorTest is Test {
         uint256 sharesBefore = mockVault0.totalSupply(projectId);
         uint256 userSharesBefore = mockVault0.balanceOf(user, projectId);
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -427,7 +428,7 @@ contract YieldExtractorTest is Test {
 
     function test_claim_twoCycles() public {
         bytes32[] memory proof = new bytes32[](1);
-        YieldExtractor.ClaimRequest[] memory payload = new YieldExtractor.ClaimRequest[](1);
+        ClaimRequest[] memory payload = new ClaimRequest[](1);
 
         // Do cycle 1 - user has 5 shares to claim
         vm.startPrank(yieldPublisher);
@@ -435,7 +436,7 @@ contract YieldExtractorTest is Test {
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         proof[0] = proof0;
-        YieldExtractor.ClaimRequest memory data1 = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data1 = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -455,7 +456,7 @@ contract YieldExtractorTest is Test {
         yieldExtractor.addTreeRoot(root1, address(mockVault0));
         vm.stopPrank();
         proof[0] = proof1;
-        YieldExtractor.ClaimRequest memory data2 = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data2 = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 2,
@@ -473,7 +474,7 @@ contract YieldExtractorTest is Test {
     function test_claim_twoVaults() public {
         bytes32[] memory proof_1 = new bytes32[](1);
         proof_1[0] = proof0;
-        YieldExtractor.ClaimRequest memory data1 = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data1 = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -483,7 +484,7 @@ contract YieldExtractorTest is Test {
 
         bytes32[] memory proof_2 = new bytes32[](1);
         proof_2[0] = proof2;
-        YieldExtractor.ClaimRequest memory data2 = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data2 = ClaimRequest({
             yelayLiteVault: address(mockVault1),
             projectId: projectId,
             cycle: 1,
@@ -499,7 +500,7 @@ contract YieldExtractorTest is Test {
         vm.stopPrank();
 
         // Claim from vault 0
-        YieldExtractor.ClaimRequest[] memory payload = new YieldExtractor.ClaimRequest[](1);
+        ClaimRequest[] memory payload = new ClaimRequest[](1);
         payload[0] = data1;
         vm.prank(user);
         vm.expectEmit(true, true, true, true);
@@ -526,7 +527,7 @@ contract YieldExtractorTest is Test {
         bytes32[] memory proof = new bytes32[](1);
         proof[0] = proof0;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -538,7 +539,7 @@ contract YieldExtractorTest is Test {
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
-        YieldExtractor.ClaimRequest[] memory payload = new YieldExtractor.ClaimRequest[](1);
+        ClaimRequest[] memory payload = new ClaimRequest[](1);
         payload[0] = data;
 
         vm.startPrank(user);
@@ -553,7 +554,7 @@ contract YieldExtractorTest is Test {
         proof[0] = proof0;
         proof[1] = proof1;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -565,7 +566,7 @@ contract YieldExtractorTest is Test {
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
-        YieldExtractor.ClaimRequest[] memory payload = new YieldExtractor.ClaimRequest[](1);
+        ClaimRequest[] memory payload = new ClaimRequest[](1);
         payload[0] = data;
 
         vm.startPrank(user);
@@ -651,7 +652,7 @@ contract YieldExtractorTest is Test {
         proof[0] = proof0;
         proof[1] = proof1;
 
-        YieldExtractor.ClaimRequest memory data = YieldExtractor.ClaimRequest({
+        ClaimRequest memory data = ClaimRequest({
             yelayLiteVault: address(mockVault0),
             projectId: projectId,
             cycle: 1,
@@ -663,7 +664,7 @@ contract YieldExtractorTest is Test {
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
-        YieldExtractor.ClaimRequest[] memory payload = new YieldExtractor.ClaimRequest[](1);
+        ClaimRequest[] memory payload = new ClaimRequest[](1);
         payload[0] = data;
 
         vm.startPrank(owner);

--- a/test/units/YieldExtractor.t.sol
+++ b/test/units/YieldExtractor.t.sol
@@ -15,7 +15,7 @@ import {LibErrors} from "src/libraries/LibErrors.sol";
 import {LibEvents} from "src/libraries/LibEvents.sol";
 import {LibRoles} from "src/libraries/LibRoles.sol";
 import {YieldExtractor} from "src/YieldExtractor.sol";
-import {ClaimRequest} from "src/interfaces/IYieldExtractor.sol";
+import {ClaimRequest, Root} from "src/interfaces/IYieldExtractor.sol";
 import {MockToken} from "test/mocks/MockToken.sol";
 import {Utils} from "test/Utils.sol";
 
@@ -138,7 +138,7 @@ contract YieldExtractorTest is Test {
         uint256 cycleBefore = yieldExtractor.cycleCount(address(mockVault0));
 
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root = Root({hash: treeRoot0, blockNumber: block.number});
         vm.expectEmit(true, true, true, true);
         emit LibEvents.PoolRootAdded(address(mockVault0), cycleBefore + 1, root.hash, root.blockNumber);
         yieldExtractor.addTreeRoot(root, address(mockVault0));
@@ -154,7 +154,7 @@ contract YieldExtractorTest is Test {
         uint256 cycleVault1 = yieldExtractor.cycleCount(address(mockVault1));
 
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root = Root({hash: treeRoot0, blockNumber: block.number});
         vm.expectEmit(true, true, true, true);
         emit LibEvents.PoolRootAdded(address(mockVault0), cycleVault0 + 1, root.hash, root.blockNumber);
         yieldExtractor.addTreeRoot(root, address(mockVault0));
@@ -166,7 +166,7 @@ contract YieldExtractorTest is Test {
         assertEq(getTreeRoot(cycleVault1, address(mockVault1)), treeRootZero);
 
         vm.startPrank(yieldPublisher);
-        root = YieldExtractor.Root({hash: treeRoot2, blockNumber: block.number});
+        root = Root({hash: treeRoot2, blockNumber: block.number});
         vm.expectEmit(true, true, true, true);
         emit LibEvents.PoolRootAdded(address(mockVault1), cycleVault1 + 1, root.hash, root.blockNumber);
         yieldExtractor.addTreeRoot(root, address(mockVault1));
@@ -185,22 +185,22 @@ contract YieldExtractorTest is Test {
                 IAccessControl.AccessControlUnauthorizedAccount.selector, address(this), LibRoles.YIELD_PUBLISHER
             )
         );
-        YieldExtractor.Root memory root = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root, address(mockVault0));
     }
 
     function test_updateRoot_success() public {
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
-        YieldExtractor.Root memory root2 = YieldExtractor.Root({hash: treeRoot2, blockNumber: block.number});
+        Root memory root2 = Root({hash: treeRoot2, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root2, address(mockVault1));
         vm.stopPrank();
 
         uint256 cycle = yieldExtractor.cycleCount(address(mockVault0));
 
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root1 = YieldExtractor.Root({hash: treeRoot1, blockNumber: block.number});
+        Root memory root1 = Root({hash: treeRoot1, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root1, address(mockVault0));
         vm.stopPrank();
 
@@ -228,7 +228,7 @@ contract YieldExtractorTest is Test {
 
     function test_updateRoot_revertInvalidCycle() public {
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
 
         vm.expectRevert(abi.encodeWithSelector(LibErrors.InvalidCycle.selector));
@@ -248,7 +248,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         assertTrue(yieldExtractor.verify(data, user));
@@ -266,7 +266,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         assertFalse(yieldExtractor.verify(data, user));
@@ -285,7 +285,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         assertFalse(yieldExtractor.verify(data, user));
@@ -303,7 +303,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
 
         // Added to different vault
         yieldExtractor.addTreeRoot(root0, address(mockVault1));
@@ -323,7 +323,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         // Using a different user than user
@@ -342,7 +342,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         assertFalse(yieldExtractor.verify(data, user));
@@ -360,7 +360,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         assertFalse(yieldExtractor.verify(data, user));
@@ -378,7 +378,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
@@ -408,7 +408,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
@@ -432,7 +432,7 @@ contract YieldExtractorTest is Test {
 
         // Do cycle 1 - user has 5 shares to claim
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
         proof[0] = proof0;
@@ -452,7 +452,7 @@ contract YieldExtractorTest is Test {
 
         // Do cycle 2 - user has another .01 shares to claim, for a total of 5.01
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root1 = YieldExtractor.Root({hash: treeRoot1, blockNumber: block.number});
+        Root memory root1 = Root({hash: treeRoot1, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root1, address(mockVault0));
         vm.stopPrank();
         proof[0] = proof1;
@@ -493,9 +493,9 @@ contract YieldExtractorTest is Test {
         });
 
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
-        YieldExtractor.Root memory root1 = YieldExtractor.Root({hash: treeRoot2, blockNumber: block.number});
+        Root memory root1 = Root({hash: treeRoot2, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root1, address(mockVault1));
         vm.stopPrank();
 
@@ -535,7 +535,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
@@ -562,7 +562,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 
@@ -660,7 +660,7 @@ contract YieldExtractorTest is Test {
             proof: proof
         });
         vm.startPrank(yieldPublisher);
-        YieldExtractor.Root memory root0 = YieldExtractor.Root({hash: treeRoot0, blockNumber: block.number});
+        Root memory root0 = Root({hash: treeRoot0, blockNumber: block.number});
         yieldExtractor.addTreeRoot(root0, address(mockVault0));
         vm.stopPrank();
 


### PR DESCRIPTION
- Implements claim + redeem on the vault (`claimAndRedeem`)
- Adds `transformFor` on the yield extractor to support that flow
- Introduces a full `IYieldExtractor` interface and aligns `YieldExtractor` with it
- Updates the status script with the changes; add missing `YieldExtractor` checks
- Fixes redeem underflow
- Extend tests
- v3.1 deployment script